### PR TITLE
security: audit repo for secret exposure, harden Actions logging, add history secret-scan

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,7 +144,8 @@ jobs:
             echo "* Cloudflare cache purged"
           else
             echo "Warning: Cache purge failed (non-critical)"
-            echo "$RESPONSE"
+            # Do not print the provider response. Error payloads can contain
+            # request details that do not belong in a public Actions log.
           fi
 
       - name: Purge jsDelivr CDN cache

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,26 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout complete history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan repository and history
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sos-build.yml
+++ b/.github/workflows/sos-build.yml
@@ -136,7 +136,9 @@ jobs:
           with open('src/sos/main.py', 'w') as f:
               f.write(content)
           
-          print(f'Injected: DNSTT_PUBKEY={bool(pubkey)}, SOS_RELAY_HOST={relay_host}')
+          # Report presence only. Values supplied through the secrets context
+          # must never be copied into a public Actions log.
+          print(f'Injected: DNSTT_PUBKEY={bool(pubkey)}, SOS_RELAY_HOST={bool(relay_host)}')
           EOF
       
       - name: Build SOS

--- a/docs/security-audit-2026-08-04.md
+++ b/docs/security-audit-2026-08-04.md
@@ -1,0 +1,92 @@
+# Secret Exposure Audit — 2026-08-04
+
+## Scope and limitations
+
+This audit covers the 265 tracked files and all 242 commits available in the
+local clone. It looks specifically for committed credentials and for workflow
+patterns that could disclose GitHub Actions secrets. Protocol design and
+implementation are intentionally out of scope for this first layer.
+
+The public GitHub Actions logs could not be downloaded from the audit
+environment because outbound access to GitHub was denied and no authenticated
+GitHub CLI session was available. Consequently, this report does **not** claim
+that historical logs were inspected. A repository administrator must complete
+the log-review checklist below.
+
+## Results
+
+### Current source tree
+
+No live credential was identified in the tracked source tree.
+
+The scan checked for private-key blocks and recognizable GitHub, AWS, Google,
+Slack, Stripe, JWT, Cloudflare, and generic credential-assignment formats.
+Candidates were manually classified as package-lock integrity hashes, bundled
+font/binary data, documented placeholders, or test fixtures. `.env.example`
+contains placeholders only.
+
+### Git history
+
+No live credential was identified in the Git objects reachable from the 242
+locally available commits. The same credential patterns were applied to 1,005
+unique blobs.
+
+Three historical `.env.example` blobs contain the literal line
+`-----BEGIN OPENSSH PRIVATE KEY-----`, but the surrounding text is documentation
+and the body is the explicit placeholder `... (the key content) ...`; it is not
+a usable key. Other candidates were dependency integrity hashes or test data.
+
+This conclusion applies only to refs present in this clone. Deleted remote
+branches, pull-request refs, forks, releases, issue attachments, and unreachable
+objects were not available for inspection.
+
+### GitHub Actions and logs
+
+The workflow definitions use the GitHub `secrets` context rather than literal
+credentials. Two avoidable logging paths were found and remediated:
+
+1. The Cloudflare cache-purge step printed the complete API error response.
+   Provider responses should be treated as sensitive diagnostic data.
+2. The SOS build printed the value of `SOS_RELAY_HOST`, despite obtaining it
+   from the secrets context. It now prints only whether a value was supplied.
+
+GitHub normally masks exact registered secret values, but masking is a safety
+net rather than a guarantee: transformed values, structured secrets, and values
+not registered with GitHub can still appear in logs.
+
+## Preventive controls added
+
+- A Gitleaks workflow scans the complete checked-out history on pushes to
+  `main`, pull requests, and manual runs.
+- Workflow permissions are explicitly read-only for that scan.
+- Known diagnostic output paths no longer print secret-derived values or full
+  provider responses.
+
+## Required administrator follow-up
+
+1. In **Actions**, inspect and download every retained run log, especially
+   `Deploy`, `Build SOS Binaries`, and `Spot VM Watchdog`. Search both plain and
+   encoded/fragmented forms of every current and retired credential.
+2. Review repository, environment, and organization Actions secrets; remove
+   unused entries and rotate credentials that have ever been printed, copied
+   into an artifact, or shared outside the secret store.
+3. Inspect Actions artifacts and releases. SOS binaries intentionally embed the
+   DNSTT public key and relay endpoint; confirm these values are non-secret and
+   name/store them accordingly to avoid a false confidentiality assumption.
+4. Review audit logs for secret reads, workflow changes, unexpected deployments,
+   and credential use from unfamiliar IP addresses.
+5. Enable GitHub secret scanning and push protection (including validity checks,
+   where available) in repository security settings.
+6. If a credential is found, revoke it first, review provider access logs, issue
+   a least-privilege replacement, delete affected logs/artifacts, and only then
+   consider history rewriting. History rewriting alone does not revoke a secret.
+
+## Risk conclusion
+
+- **Tracked code:** no exposed live secret found; moderate confidence.
+- **Reachable local history:** no exposed live secret found; moderate confidence.
+- **Historical Actions logs/artifacts:** not verified; status unknown until an
+  administrator performs the required review.
+
+This is a point-in-time secret-exposure review, not a guarantee that credentials
+were never exposed or that the protocol implementations are secure.


### PR DESCRIPTION
### Motivation

- Perform a point-in-time secret-exposure audit across the tracked source and reachable Git history to detect committed credentials and reduce the risk of leaking secrets via CI logs.
- Prevent accidental disclosure of secret-derived values or provider responses in public GitHub Actions logs.
- Add an automated, history-aware scanning workflow so future pushes and PRs are checked for secrets.

### Description

- Stop printing full provider responses in the Cloudflare cache-purge step by removing the `echo "$RESPONSE"` line in `.github/workflows/deploy.yml` so error payloads are not emitted to Actions logs.
- Stop printing secret-derived relay values during SOS builds by changing the build step in `.github/workflows/sos-build.yml` to only report presence via `bool(...)` instead of printing the actual `SOS_RELAY_HOST` value.
- Add a read-only history-aware secret scan workflow `.github/workflows/secret-scan.yml` using `gitleaks/gitleaks-action@v2` that checks the complete checkout (`fetch-depth: 0`) on pushes to `main`, pull requests, and manual runs.
- Add a human-readable audit report `docs/security-audit-2026-08-04.md` documenting scope, findings, and required administrator follow-up (notably that Actions logs/artifacts needed administrative access to verify).

### Testing

- Ran `git diff --check` and fixed no whitespace or patch-check issues, which succeeded.
- Parsed every workflow YAML with `ruby` (`YAML.load_file`) and validated shell scripts with `bash -n`, both of which succeeded for modified and existing workflows and scripts.
- Performed a custom credential-pattern scan across `git ls-files` (265 tracked files) and reachable history blobs (1,005 unique blobs from 242 reachable commits) which found no live, usable credentials in the tracked tree or reachable history; matches were classed as dependency integrity hashes, bundled binary/font data, documented placeholders, or test fixtures.
- Attempted to run network-backed scanners and fetch GitHub Actions logs but the audit environment prevented outbound GitHub access and package downloads (network `403`/CLI unauthenticated), so external scans and historical Actions-log verification were not possible here and are listed as required administrator follow-up in the audit doc.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71bf2e48dc83319ff8ea59c1f4363f)