### PR TITLE
Add top-protocols endpoint analytics and UI panel

### DIFF
--- a/workers/src/__tests__/traffic-analytics.test.ts
+++ b/workers/src/__tests__/traffic-analytics.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { topProtocolsFromEndpoints } from '../traffic-analytics.js';
+
+describe('topProtocolsFromEndpoints', () => {
+  it('aggregates protocol endpoint and child-path requests', () => {
+    const protocols = topProtocolsFromEndpoints([
+      { dimensions: { clientRequestPath: '/reality' }, sum: { requests: 12 } },
+      { dimensions: { clientRequestPath: '/reality/setup/linux' }, sum: { requests: 8 } },
+      { dimensions: { clientRequestPath: '/dnstt/client' }, sum: { requests: 15 } },
+      { dimensions: { clientRequestPath: '/docs' }, sum: { requests: 100 } },
+      { dimensions: { clientRequestPath: '/' }, sum: { requests: 200 } },
+    ]);
+
+    expect(protocols).toEqual([
+      { endpoint: 'reality', name: 'VLESS + REALITY', requests: 20 },
+      { endpoint: 'dnstt', name: 'DNS Tunnel', requests: 15 },
+    ]);
+  });
+
+  it('limits the result and handles absent analytics fields', () => {
+    const protocols = topProtocolsFromEndpoints([
+      {},
+      { dimensions: { clientRequestPath: '/wg?source=home' }, sum: { requests: 2 } },
+      { dimensions: { clientRequestPath: '/WS' }, sum: { requests: 4 } },
+    ], 1);
+
+    expect(protocols).toEqual([
+      { endpoint: 'ws', name: 'VLESS + WS + CDN', requests: 4 },
+    ]);
+  });
+});

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -16,6 +16,7 @@ import { handleTuiRequest } from './tui/index.js';
 import { pageLandingBash } from './tui/pages/landing.js';
 import { handleBoxCreate, handleBoxFetch, handleBoxPage } from './safebox.js';
 import { handleVless } from './vless.js';
+import { topProtocolsFromEndpoints, type EndpointAnalyticsRow } from './traffic-analytics.js';
 
 const GITHUB_RAW = 'https://raw.githubusercontent.com/behnamkhorsandian/Vanysh/main';
 
@@ -29,6 +30,7 @@ interface CloudflareAnalyticsRow {
   dimensions?: {
     date?: string;
     clientCountryName?: string;
+    clientRequestPath?: string;
   };
   sum?: {
     requests?: number;
@@ -44,6 +46,7 @@ interface CloudflareAnalyticsResponse {
       zones?: Array<{
         daily?: CloudflareAnalyticsRow[];
         countries?: CloudflareAnalyticsRow[];
+        endpoints?: EndpointAnalyticsRow[];
       }>;
     };
   };
@@ -96,6 +99,13 @@ async function getCloudflareTraffic(request: Request, env: Env, ctx: ExecutionCo
             filter: { date_geq: $start, date_lt: $end, requestSource: "eyeball" }
           ) {
             dimensions { date clientCountryName }
+            sum { requests }
+          }
+          endpoints: httpRequests1dGroups(
+            limit: 10000
+            filter: { date_geq: $start, date_lt: $end, requestSource: "eyeball" }
+          ) {
+            dimensions { clientRequestPath }
             sum { requests }
           }
         }
@@ -167,6 +177,7 @@ async function getCloudflareTraffic(request: Request, env: Env, ctx: ExecutionCo
     lowVisitors: visitorCounts.length ? Math.min(...visitorCounts) : 0,
     requests: daily.reduce((total, day) => total + day.requests, 0),
     countries,
+    protocols: topProtocolsFromEndpoints(zone.endpoints || []),
     daily,
     updatedAt: new Date().toISOString(),
   }, { headers: responseHeaders });

--- a/workers/src/traffic-analytics.ts
+++ b/workers/src/traffic-analytics.ts
@@ -1,0 +1,50 @@
+export interface EndpointAnalyticsRow {
+  dimensions?: {
+    clientRequestPath?: string;
+  };
+  sum?: {
+    requests?: number;
+  };
+}
+
+const PROTOCOL_ENDPOINTS: Record<string, string> = {
+  mtp: 'MTProto',
+  reality: 'VLESS + REALITY',
+  wg: 'WireGuard',
+  vray: 'VLESS + TLS',
+  ws: 'VLESS + WS + CDN',
+  dnstt: 'DNS Tunnel',
+  conduit: 'Conduit',
+  hysteria: 'Hysteria v2',
+  'http-obfs': 'HTTP Obfuscation',
+  'ssh-tunnel': 'SSH Tunnel',
+  noizdns: 'NoizDNS',
+  slipstream: 'Slipstream',
+  snowflake: 'Snowflake',
+  'tor-bridge': 'Tor Bridge',
+  sos: 'SOS Chat',
+};
+
+/**
+ * Treat requests to a protocol's top-level endpoint (including its child paths)
+ * as a usage proxy. Cloudflare zone analytics cannot identify the protocol a
+ * visitor eventually installs, but the endpoint they request provides a useful
+ * aggregate signal without tracking individual users.
+ */
+export function topProtocolsFromEndpoints(rows: EndpointAnalyticsRow[], limit = 5) {
+  const totals = new Map<string, number>();
+
+  for (const row of rows) {
+    const path = row.dimensions?.clientRequestPath || '';
+    const endpoint = path.split('?')[0].split('/').filter(Boolean)[0]?.toLowerCase();
+    const name = endpoint && PROTOCOL_ENDPOINTS[endpoint];
+    if (!name) continue;
+
+    totals.set(endpoint, (totals.get(endpoint) || 0) + (row.sum?.requests || 0));
+  }
+
+  return Array.from(totals.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([endpoint, requests]) => ({ endpoint, name: PROTOCOL_ENDPOINTS[endpoint], requests }));
+}

--- a/www/index.html
+++ b/www/index.html
@@ -1641,7 +1641,12 @@
       letter-spacing: 0.08em;
       text-transform: uppercase;
     }
-    .cloud-country-panel { padding: 18px 0 8px; }
+    .cloud-breakdowns {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 32px;
+    }
+    .cloud-country-panel { min-width: 0; padding: 18px 0 8px; }
     .cloud-country-title {
       margin-bottom: 14px;
       color: var(--text-dim);
@@ -1661,6 +1666,7 @@
     .cloud-country-track { height: 2px; background: var(--border-soft); }
     .cloud-country-bar { display: block; height: 100%; background: var(--text-secondary); }
     .cloud-country-value { color: var(--text-dim); text-align: right; }
+    #traffic-protocols .cloud-country-row { grid-template-columns: 136px minmax(80px, 1fr) 72px; }
 
     /* Documentation */
     .sidebar {
@@ -1721,7 +1727,9 @@
       .cloud-stat { border-bottom: 1px solid var(--border-soft); }
       .cloud-stat:nth-child(2n) { border-right: 0; }
       .cloud-stat:last-child { grid-column: span 2; border-bottom: 0; }
+      .cloud-breakdowns { grid-template-columns: 1fr; gap: 0; }
       .cloud-country-row { grid-template-columns: 76px minmax(60px, 1fr) 62px; gap: 9px; }
+      #traffic-protocols .cloud-country-row { grid-template-columns: 116px minmax(60px, 1fr) 62px; }
       .mobile-menu-btn { right: 16px; bottom: 16px; width: 46px; height: 46px; }
     }
   </style>
@@ -1824,33 +1832,45 @@
                 <span class="cloud-stat-label">Days measured</span>
               </div>
             </div>
-            <div class="cloud-country-panel">
-              <div class="cloud-country-title">Top traffic countries and regions</div>
-              <div class="cloud-country-list" id="traffic-countries">
-                <div class="cloud-country-row">
-                  <span class="cloud-country-name">Netherlands</span>
-                  <span class="cloud-country-track"><span class="cloud-country-bar" style="width:100%"></span></span>
-                  <span class="cloud-country-value">41,014</span>
+            <div class="cloud-breakdowns">
+              <div class="cloud-country-panel">
+                <div class="cloud-country-title">Top traffic countries and regions</div>
+                <div class="cloud-country-list" id="traffic-countries">
+                  <div class="cloud-country-row">
+                    <span class="cloud-country-name">Netherlands</span>
+                    <span class="cloud-country-track"><span class="cloud-country-bar" style="width:100%"></span></span>
+                    <span class="cloud-country-value">41,014</span>
+                  </div>
+                  <div class="cloud-country-row">
+                    <span class="cloud-country-name">France</span>
+                    <span class="cloud-country-track"><span class="cloud-country-bar" style="width:48.4%"></span></span>
+                    <span class="cloud-country-value">19,842</span>
+                  </div>
+                  <div class="cloud-country-row">
+                    <span class="cloud-country-name">Brazil</span>
+                    <span class="cloud-country-track"><span class="cloud-country-bar" style="width:31.7%"></span></span>
+                    <span class="cloud-country-value">12,997</span>
+                  </div>
+                  <div class="cloud-country-row">
+                    <span class="cloud-country-name">United States</span>
+                    <span class="cloud-country-track"><span class="cloud-country-bar" style="width:31%"></span></span>
+                    <span class="cloud-country-value">12,725</span>
+                  </div>
+                  <div class="cloud-country-row">
+                    <span class="cloud-country-name">Canada</span>
+                    <span class="cloud-country-track"><span class="cloud-country-bar" style="width:12.4%"></span></span>
+                    <span class="cloud-country-value">5,090</span>
+                  </div>
                 </div>
-                <div class="cloud-country-row">
-                  <span class="cloud-country-name">France</span>
-                  <span class="cloud-country-track"><span class="cloud-country-bar" style="width:48.4%"></span></span>
-                  <span class="cloud-country-value">19,842</span>
-                </div>
-                <div class="cloud-country-row">
-                  <span class="cloud-country-name">Brazil</span>
-                  <span class="cloud-country-track"><span class="cloud-country-bar" style="width:31.7%"></span></span>
-                  <span class="cloud-country-value">12,997</span>
-                </div>
-                <div class="cloud-country-row">
-                  <span class="cloud-country-name">United States</span>
-                  <span class="cloud-country-track"><span class="cloud-country-bar" style="width:31%"></span></span>
-                  <span class="cloud-country-value">12,725</span>
-                </div>
-                <div class="cloud-country-row">
-                  <span class="cloud-country-name">Canada</span>
-                  <span class="cloud-country-track"><span class="cloud-country-bar" style="width:12.4%"></span></span>
-                  <span class="cloud-country-value">5,090</span>
+              </div>
+              <div class="cloud-country-panel">
+                <div class="cloud-country-title">Top protocols <span title="Estimated from protocol endpoint requests">/ endpoint traffic proxy</span></div>
+                <div class="cloud-country-list" id="traffic-protocols">
+                  <div class="cloud-country-row">
+                    <span class="cloud-country-name">Loading</span>
+                    <span class="cloud-country-track"><span class="cloud-country-bar" style="width:100%"></span></span>
+                    <span class="cloud-country-value">--</span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -3140,6 +3160,34 @@
 
         row.append(name, track, value);
         list.appendChild(row);
+      });
+
+      const protocols = Array.isArray(data.protocols) ? data.protocols : [];
+      const protocolList = document.getElementById('traffic-protocols');
+      const protocolMaximum = Math.max(...protocols.map(protocol => Number(protocol.requests) || 0), 1);
+      protocolList.replaceChildren();
+
+      protocols.slice(0, 5).forEach(protocol => {
+        const row = document.createElement('div');
+        row.className = 'cloud-country-row';
+
+        const name = document.createElement('span');
+        name.className = 'cloud-country-name';
+        name.textContent = protocol.name || protocol.endpoint || 'Unknown';
+
+        const track = document.createElement('span');
+        track.className = 'cloud-country-track';
+        const bar = document.createElement('span');
+        bar.className = 'cloud-country-bar';
+        bar.style.width = Math.max(2, ((Number(protocol.requests) || 0) / protocolMaximum) * 100) + '%';
+        track.appendChild(bar);
+
+        const value = document.createElement('span');
+        value.className = 'cloud-country-value';
+        value.textContent = (Number(protocol.requests) || 0).toLocaleString();
+
+        row.append(name, track, value);
+        protocolList.appendChild(row);
       });
     }
 


### PR DESCRIPTION
### Motivation

- Provide per-protocol visibility in the Cloudflare traffic stats by using endpoint request paths as a privacy-preserving proxy for protocol interest. 
- Surface the most-requested protocol endpoints on the public site without leaking raw analytics credentials to the browser. 

### Description

- Add `workers/src/traffic-analytics.ts` with `topProtocolsFromEndpoints` to normalize endpoint paths and aggregate request counts per protocol endpoint. 
- Extend the Cloudflare GraphQL query and handler in `workers/src/index.ts` to request endpoint path groups, call `topProtocolsFromEndpoints`, and include a `protocols` array in the `/traffic-stats` JSON response. 
- Add unit tests in `workers/src/__tests__/traffic-analytics.test.ts` covering aggregation, child-path handling, query strings, limits, and absent fields. 
- Update `www/index.html` to add a responsive “Top protocols / endpoint traffic proxy” breakdown panel, client-side rendering logic for the top-five protocols, and small CSS adjustments for layout. 

### Testing

- Ran unit tests with `cd workers && npm test`, and all worker tests passed (`70 passed, 1 skipped`).
- Verified TypeScript types with `npx tsc --noEmit` which completed successfully. 
- Performed an HTML parse sanity-check of `www/index.html` with `python3` which succeeded. 
- Ran `scripts/tools/protocol-smoke.sh` which started registry checks but could not validate Docker Compose due to `docker` not being available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71f4438d688331b24c825d7eae3290)