### PR TITLE
Detect protocol from HTTP host (subdomain) in traffic analytics

### DIFF
--- a/workers/src/__tests__/traffic-analytics.test.ts
+++ b/workers/src/__tests__/traffic-analytics.test.ts
@@ -17,6 +17,21 @@ describe('topProtocolsFromEndpoints', () => {
     ]);
   });
 
+  it('aggregates protocol subdomain requests when the path is not protocol-specific', () => {
+    const protocols = topProtocolsFromEndpoints([
+      { dimensions: { clientRequestHTTPHost: 'mtp.vany.sh', clientRequestPath: '/' }, sum: { requests: 7 } },
+      { dimensions: { clientRequestHTTPHost: 'wg.vany.sh', clientRequestPath: '/' }, sum: { requests: 3 } },
+      { dimensions: { clientRequestHTTPHost: 'www.vany.sh', clientRequestPath: '/' }, sum: { requests: 10 } },
+      { dimensions: { clientRequestHTTPHost: 'vany.sh', clientRequestPath: '/ws' }, sum: { requests: 4 } },
+    ]);
+
+    expect(protocols).toEqual([
+      { endpoint: 'mtp', name: 'MTProto', requests: 7 },
+      { endpoint: 'ws', name: 'VLESS + WS + CDN', requests: 4 },
+      { endpoint: 'wg', name: 'WireGuard', requests: 3 },
+    ]);
+  });
+
   it('limits the result and handles absent analytics fields', () => {
     const protocols = topProtocolsFromEndpoints([
       {},

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -31,6 +31,7 @@ interface CloudflareAnalyticsRow {
     date?: string;
     clientCountryName?: string;
     clientRequestPath?: string;
+    clientRequestHTTPHost?: string;
   };
   sum?: {
     requests?: number;
@@ -105,7 +106,7 @@ async function getCloudflareTraffic(request: Request, env: Env, ctx: ExecutionCo
             limit: 10000
             filter: { date_geq: $start, date_lt: $end, requestSource: "eyeball" }
           ) {
-            dimensions { clientRequestPath }
+            dimensions { clientRequestPath clientRequestHTTPHost }
             sum { requests }
           }
         }

--- a/workers/src/traffic-analytics.ts
+++ b/workers/src/traffic-analytics.ts
@@ -1,6 +1,7 @@
 export interface EndpointAnalyticsRow {
   dimensions?: {
     clientRequestPath?: string;
+    clientRequestHTTPHost?: string;
   };
   sum?: {
     requests?: number;
@@ -25,20 +26,31 @@ const PROTOCOL_ENDPOINTS: Record<string, string> = {
   sos: 'SOS Chat',
 };
 
+function protocolEndpointFromRow(row: EndpointAnalyticsRow): string | undefined {
+  const path = row.dimensions?.clientRequestPath || '';
+  const pathEndpoint = path.split('?')[0].split('/').filter(Boolean)[0]?.toLowerCase();
+  if (pathEndpoint && PROTOCOL_ENDPOINTS[pathEndpoint]) return pathEndpoint;
+
+  const host = (row.dimensions?.clientRequestHTTPHost || '').toLowerCase();
+  const hostEndpoint = host.endsWith('.vany.sh') ? host.slice(0, -'.vany.sh'.length).split('.').pop() : '';
+  if (!hostEndpoint) return undefined;
+
+  return PROTOCOL_ENDPOINTS[hostEndpoint] ? hostEndpoint : undefined;
+}
+
 /**
  * Treat requests to a protocol's top-level endpoint (including its child paths)
- * as a usage proxy. Cloudflare zone analytics cannot identify the protocol a
- * visitor eventually installs, but the endpoint they request provides a useful
- * aggregate signal without tracking individual users.
+ * or fallback subdomain as a usage proxy. Cloudflare zone analytics cannot
+ * identify the protocol a visitor eventually installs, but the endpoint or
+ * fallback host they request provides a useful aggregate signal without
+ * tracking individual users.
  */
 export function topProtocolsFromEndpoints(rows: EndpointAnalyticsRow[], limit = 5) {
   const totals = new Map<string, number>();
 
   for (const row of rows) {
-    const path = row.dimensions?.clientRequestPath || '';
-    const endpoint = path.split('?')[0].split('/').filter(Boolean)[0]?.toLowerCase();
-    const name = endpoint && PROTOCOL_ENDPOINTS[endpoint];
-    if (!name) continue;
+    const endpoint = protocolEndpointFromRow(row);
+    if (!endpoint) continue;
 
     totals.set(endpoint, (totals.get(endpoint) || 0) + (row.sum?.requests || 0));
   }


### PR DESCRIPTION
### Motivation
- Improve protocol usage aggregation by recognizing protocol-specific subdomains (e.g. `mtp.vany.sh`) when the request path is not protocol-specific. 

### Description
- Add `clientRequestHTTPHost` to the Cloudflare GraphQL query in `workers/src/index.ts` so analytics include the request host. 
- Extend the `EndpointAnalyticsRow` type and implement `protocolEndpointFromRow` in `workers/src/traffic-analytics.ts` to derive an endpoint first from the request path and then from the `.vany.sh` subdomain fallback. 
- Refactor `topProtocolsFromEndpoints` to use the new helper and accumulate request totals accordingly. 
- Add a unit test `workers/src/__tests__/traffic-analytics.test.ts` to verify aggregation from subdomain hosts alongside the existing path-based tests. 

### Testing
- Ran unit tests with `vitest` which include the updated `traffic-analytics` specs, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a730f198e608331abd4f4d9953bd022)