### PR TITLE
Update top protocol stats display and analytics labels

### DIFF
--- a/workers/src/__tests__/traffic-analytics.test.ts
+++ b/workers/src/__tests__/traffic-analytics.test.ts
@@ -26,8 +26,8 @@ describe('topProtocolsFromEndpoints', () => {
     ]);
 
     expect(protocols).toEqual([
-      { endpoint: 'mtp', name: 'MTProto', requests: 7 },
-      { endpoint: 'ws', name: 'VLESS + WS + CDN', requests: 4 },
+      { endpoint: 'mtp', name: 'MTP protocol', requests: 7 },
+      { endpoint: 'ws', name: 'VLESS Websocket', requests: 4 },
       { endpoint: 'wg', name: 'WireGuard', requests: 3 },
     ]);
   });
@@ -40,7 +40,7 @@ describe('topProtocolsFromEndpoints', () => {
     ], 1);
 
     expect(protocols).toEqual([
-      { endpoint: 'ws', name: 'VLESS + WS + CDN', requests: 4 },
+      { endpoint: 'ws', name: 'VLESS Websocket', requests: 4 },
     ]);
   });
 });

--- a/workers/src/traffic-analytics.ts
+++ b/workers/src/traffic-analytics.ts
@@ -9,11 +9,11 @@ export interface EndpointAnalyticsRow {
 }
 
 const PROTOCOL_ENDPOINTS: Record<string, string> = {
-  mtp: 'MTProto',
+  mtp: 'MTP protocol',
   reality: 'VLESS + REALITY',
   wg: 'WireGuard',
   vray: 'VLESS + TLS',
-  ws: 'VLESS + WS + CDN',
+  ws: 'VLESS Websocket',
   dnstt: 'DNS Tunnel',
   conduit: 'Conduit',
   hysteria: 'Hysteria v2',

--- a/www/index.html
+++ b/www/index.html
@@ -1873,14 +1873,19 @@
                 <div class="cloud-country-title">Top protocols <span title="Estimated from protocol endpoint requests">/ endpoint traffic proxy</span></div>
                 <div class="cloud-country-list" id="traffic-protocols">
                   <div class="cloud-country-row">
-                    <span class="cloud-country-name">SafeBox</span>
+                    <span class="cloud-country-name">MTP protocol</span>
                     <span class="cloud-country-track"><span class="cloud-country-bar" style="width:100%"></span></span>
-                    <span class="cloud-country-value">live</span>
+                    <span class="cloud-country-value">top</span>
                   </div>
                   <div class="cloud-country-row">
-                    <span class="cloud-country-name">Install</span>
+                    <span class="cloud-country-name">WireGuard</span>
                     <span class="cloud-country-track"><span class="cloud-country-bar" style="width:72%"></span></span>
-                    <span class="cloud-country-value">ready</span>
+                    <span class="cloud-country-value">2</span>
+                  </div>
+                  <div class="cloud-country-row">
+                    <span class="cloud-country-name">VLESS Websocket</span>
+                    <span class="cloud-country-track"><span class="cloud-country-bar" style="width:48%"></span></span>
+                    <span class="cloud-country-value">3</span>
                   </div>
                 </div>
               </div>
@@ -3177,7 +3182,7 @@
       const protocolList = document.getElementById('traffic-protocols');
       protocolList.replaceChildren();
       if (!protocols.length) {
-        [['SafeBox', 'live'], ['Install', 'ready'], ['Docs', 'ready']].forEach((item, index) => {
+        [['MTP protocol', 'top'], ['WireGuard', '2'], ['VLESS Websocket', '3']].forEach((item, index) => {
           const row = document.createElement('div');
           row.className = 'cloud-country-row';
           const name = document.createElement('span');


### PR DESCRIPTION
### Motivation
- Reflect a requested change in the Top protocols panel to show MTP as top, WireGuard as second, and VLESS Websocket as third in the static site fallback and live display.
- Keep runtime analytics labels consistent with the UI so endpoint-derived protocol names match what users see on the landing page.

### Description
- Updated static markup in `www/index.html` to replace the previous fallback rows with `MTP protocol`, `WireGuard`, and `VLESS Websocket` and adjusted their displayed values and bar widths.
- Updated the no-data fallback renderer in `www/index.html` so the same three protocol rows are used when `/traffic-stats` returns no protocol payload.
- Changed protocol labels in `workers/src/traffic-analytics.ts` by mapping `mtp` → `MTP protocol` and `ws` → `VLESS Websocket` in `PROTOCOL_ENDPOINTS` to match the new UI strings.
- Adjusted expectations in `workers/src/__tests__/traffic-analytics.test.ts` to match the updated labels.

### Testing
- Ran the worker test suite with `npm test --prefix workers` (Vitest), which completed successfully with the worker tests reporting `71 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a731e4f38548331b00d5060f927f00c)